### PR TITLE
fix(library.properties): update the `architectures`  definition

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,4 +6,4 @@ sentence=Handle strings from an XBox controller receiver (ESP controller running
 paragraph=Designed to communicate with an ESP controller running BluePad over Serial1 expecting specific strings describing the state of the various inputs available on an XBox bluetooth controller.
 category=Signal Input/Output
 url=https://github.com/nruin7/Arduino-XBox-Controller-Handler
-architectures=["*"]
+architectures=*


### PR DESCRIPTION
## Motivation
Following the  [Arduino Library Definition](https://docs.arduino.cc/arduino-cli/library-specification/)  the architectures field can be the single `*` to match all architectures.

## Changes 
Remove the opening `[` and closing `]` parenthesis (like other [Arduino library](https://github.com/arduino-libraries/NTPClient/blob/61684d4516839b579b81105be3447499c1417908/library.properties#L9) )


## Expected result
(After the library has been indexed) The `Compatibility` section of the [LIbrary docs](https://docs.arduino.cc/libraries/xboxcontrollerhandler/) is updated from `This library is compatible with the ["*"] architectures` to `This library is compatible with all architectures`