### PR TITLE
chore: update .gitattributes to exclude dev files from release

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,9 @@
 * text=auto
+
+# Exclude development-only content from release archives
+dev/        export-ignore
+.vscode/    export-ignore
+.github/    export-ignore
+tests/      export-ignore
+*.ps1       export-ignore
+build/      export-ignore


### PR DESCRIPTION
What
Excludes development files from releases.

Why
To prevent cloned repo development resources from ending up in Arduino library manager downloads.